### PR TITLE
feat(submission): Bithumb - Back Young Heo

### DIFF
--- a/submissions/bithumb-back-young-heo.json
+++ b/submissions/bithumb-back-young-heo.json
@@ -1,0 +1,6 @@
+{
+  "date": 1604918198581,
+  "description": "Website: bithumb.com\nCompany: Bithumb Korea Co. Ltd.\nLocation: Korea\n\nListing Price: $30000\nFake Volume: Yes\n\nHacked: $13 Mio (2019), $31 Mio (2018), $10 Mio (2017)\nShitcoin: BT\n\n\"DEX\" lol: No\n\nhttps://kr.linkedin.com/in/backyoung\nhttps://www.coindesk.com/crypto-exchange-bithumb-hacked-for-13-million-in-suspected-insider-job\nhttps://www.coindesk.com/bithumb-exchanges-31-million-hack-know-dont-know\nhttps://www.bleepingcomputer.com/news/security/fourth-largest-cryptocurrency-exchange-was-hacked-users-lose-ethereum-and-bitcoin/",
+  "name": "Bithumb",
+  "title": "Back Young Heo"
+}


### PR DESCRIPTION
# Back Young Heo
## by Bithumb
> Website: bithumb.com
Company: Bithumb Korea Co. Ltd.
Location: Korea

Listing Price: $30000
Fake Volume: Yes

Hacked: $13 Mio (2019), $31 Mio (2018), $10 Mio (2017)
Shitcoin: BT

"DEX" lol: No

https://kr.linkedin.com/in/backyoung
https://www.coindesk.com/crypto-exchange-bithumb-hacked-for-13-million-in-suspected-insider-job
https://www.coindesk.com/bithumb-exchanges-31-million-hack-know-dont-know
https://www.bleepingcomputer.com/news/security/fourth-largest-cryptocurrency-exchange-was-hacked-users-lose-ethereum-and-bitcoin/