### PR TITLE
feat(submission): Bibox.com - Jeffery Lei

### DIFF
--- a/submissions/biboxcom-jeffery-lei.json
+++ b/submissions/biboxcom-jeffery-lei.json
@@ -1,0 +1,6 @@
+{
+  "date": 1609115227819,
+  "description": "Puchased COVER tokens at 120$, next day my amount was removed. Contacted Support, that stated they were resolving an issue regarding COVER tokens. \nWaited 1 week still nothing, whent to check my COVER balance, wallet was removed. I has an uneased feeling I was being duped, my Cover balance was transfered to SAFE token wallet. Contacted again, they stated that the commissioner was reviewing the issue.\nContacted 1 week later, my inicial amount I used to purchase Cover was back on my wallet and no COVER tokens to be seen. All in all I had lost around 2500$ and they told me it was the best they could do.",
+  "name": "Bibox.com",
+  "title": "Jeffery Lei"
+}


### PR DESCRIPTION
# Jeffery Lei
## by Bibox.com
> Puchased COVER tokens at 120$, next day my amount was removed. Contacted Support, that stated they were resolving an issue regarding COVER tokens. 
Waited 1 week still nothing, whent to check my COVER balance, wallet was removed. I has an uneased feeling I was being duped, my Cover balance was transfered to SAFE token wallet. Contacted again, they stated that the commissioner was reviewing the issue.
Contacted 1 week later, my inicial amount I used to purchase Cover was back on my wallet and no COVER tokens to be seen. All in all I had lost around 2500$ and they told me it was the best they could do.